### PR TITLE
fix: 与 @vitejs/plugin-legacy 插件使用时会有问题

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,7 +37,7 @@ function vitePrerender(options: VitePluginPrerender): Plugin {
         : path.join(config.root, config.build.outDir)
       debug('resolvedConfig:', resolvedConfig)
     },
-    async writeBundle(options,bundle){
+    async closeBundle(options,bundle){
       await emitRendered(_options)
     }
   }


### PR DESCRIPTION
与 `@vitejs/plugin-legacy` 插件使用时会有问题， 初步判断是钩子函数问题，修复成使用 `closeBundle` 在服务器关闭时被调用。